### PR TITLE
Add partners section between about and pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,14 +393,14 @@
             
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
                 <!-- Partner 1 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
-                    <div class="h-48 bg-gray-200 flex items-center justify-center">
-                        <img src="https://monikiweb.ru/templates/moniki/images/logo.png" alt="МОНИКИ им. М.Ф. Владимирского" class="max-h-32 max-w-full p-4">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://i.ibb.co/Jj9LKND/moniki-logo.png" alt="МОНИКИ им. М.Ф. Владимирского" class="max-h-32 max-w-full p-4">
                     </div>
-                    <div class="p-6">
+                    <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "МОНИКИ им. М.Ф. Владимирского"</h3>
-                        <p class="text-gray-600 mb-4">Ведущий научно-исследовательский и лечебный центр Московской области, специализирующийся на разработке и внедрении новых методов диагностики и лечения.</p>
-                        <div class="flex items-center text-sm text-gray-500">
+                        <p class="text-gray-600 mb-4 flex-grow">Ведущий научно-исследовательский и лечебный центр Московской области, специализирующийся на разработке и внедрении новых методов диагностики и лечения.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
                             <span>г. Москва, ул. Щепкина, 61/2</span>
                         </div>
@@ -408,14 +408,14 @@
                 </div>
                 
                 <!-- Partner 2 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
-                    <div class="h-48 bg-gray-200 flex items-center justify-center">
-                        <img src="https://botkinmoscow.ru/upload/iblock/a0c/a0c4d1a9a5a5e8c5e8c5e8c5e8c5e8c5.png" alt="Центр имени С.П. Боткина" class="max-h-32 max-w-full p-4">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://i.ibb.co/Qf7Lvxb/botkin-logo.png" alt="Центр имени С.П. Боткина" class="max-h-32 max-w-full p-4">
                     </div>
-                    <div class="p-6">
+                    <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «Московский многопрофильный центр имени С.П. Боткина»</h3>
-                        <p class="text-gray-600 mb-4">Один из крупнейших многопрофильных медицинских центров Москвы с богатой историей и современным оборудованием.</p>
-                        <div class="flex items-center text-sm text-gray-500">
+                        <p class="text-gray-600 mb-4 flex-grow">Один из крупнейших многопрофильных медицинских центров Москвы с богатой историей и современным оборудованием.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
                             <span>г. Москва, 2-й Боткинский проезд, 5</span>
                         </div>
@@ -423,14 +423,14 @@
                 </div>
                 
                 <!-- Partner 3 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
-                    <div class="h-48 bg-gray-200 flex items-center justify-center">
-                        <img src="https://sklif.mos.ru/upload/medialibrary/e97/e97a75d3f4c919a289ebfa47a4a1c5c0.png" alt="НИИ скорой помощи им. Н.В. Склифосовского" class="max-h-32 max-w-full p-4">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://i.ibb.co/Jc9Hnzw/sklif-logo.png" alt="НИИ скорой помощи им. Н.В. Склифосовского" class="max-h-32 max-w-full p-4">
                     </div>
-                    <div class="p-6">
+                    <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «НИИ скорой помощи им. Н.В. Склифосовского»</h3>
-                        <p class="text-gray-600 mb-4">Ведущее учреждение экстренной медицинской помощи, специализирующееся на лечении неотложных состояний и травм.</p>
-                        <div class="flex items-center text-sm text-gray-500">
+                        <p class="text-gray-600 mb-4 flex-grow">Ведущее учреждение экстренной медицинской помощи, специализирующееся на лечении неотложных состояний и травм.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
                             <span>г. Москва, Большая Сухаревская площадь, 3</span>
                         </div>
@@ -438,14 +438,14 @@
                 </div>
                 
                 <!-- Partner 4 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
-                    <div class="h-48 bg-gray-200 flex items-center justify-center">
-                        <img src="https://67gkb.ru/local/templates/gkb67/images/logo.svg" alt="ГКБ № 67 им. Л.А. Ворохобова" class="max-h-32 max-w-full p-4">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://i.ibb.co/Qj9Nt9L/gkb67-logo.png" alt="ГКБ № 67 им. Л.А. Ворохобова" class="max-h-32 max-w-full p-4">
                     </div>
-                    <div class="p-6">
+                    <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «ГКБ № 67 им. Л.А. Ворохобова»</h3>
-                        <p class="text-gray-600 mb-4">Многопрофильная клиническая больница с современным оборудованием и высококвалифицированными специалистами.</p>
-                        <div class="flex items-center text-sm text-gray-500">
+                        <p class="text-gray-600 mb-4 flex-grow">Многопрофильная клиническая больница с современным оборудованием и высококвалифицированными специалистами.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
                             <span>г. Москва, ул. Саляма Адиля, 2/44</span>
                         </div>
@@ -453,14 +453,14 @@
                 </div>
                 
                 <!-- Partner 5 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
-                    <div class="h-48 bg-gray-200 flex items-center justify-center">
-                        <img src="https://ssmp.mos.ru/images/logo.png" alt="Станция скорой помощи им. А.С. Пучкова" class="max-h-32 max-w-full p-4">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://i.ibb.co/Jj9LKND/ssmp-logo.png" alt="Станция скорой помощи им. А.С. Пучкова" class="max-h-32 max-w-full p-4">
                     </div>
-                    <div class="p-6">
+                    <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «Станция скорой помощи им. А.С. Пучкова»</h3>
-                        <p class="text-gray-600 mb-4">Крупнейшая в Европе станция скорой медицинской помощи, обеспечивающая экстренную помощь жителям Москвы.</p>
-                        <div class="flex items-center text-sm text-gray-500">
+                        <p class="text-gray-600 mb-4 flex-grow">Крупнейшая в Европе станция скорой медицинской помощи, обеспечивающая экстренную помощь жителям Москвы.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
                             <span>г. Москва, 1-й Коптельский пер., 3, стр. 1</span>
                         </div>
@@ -468,14 +468,14 @@
                 </div>
                 
                 <!-- Partner 6 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
-                    <div class="h-48 bg-gray-200 flex items-center justify-center">
-                        <img src="https://mytishchi-okb.ru/wp-content/uploads/2022/01/logo.png" alt="Мытищинская ОКБ" class="max-h-32 max-w-full p-4">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://i.ibb.co/Qj9Nt9L/mytishi-logo.png" alt="Мытищинская ОКБ" class="max-h-32 max-w-full p-4">
                     </div>
-                    <div class="p-6">
+                    <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "Мытищинская ОКБ"</h3>
-                        <p class="text-gray-600 mb-4">Областная клиническая больница, оказывающая широкий спектр медицинских услуг населению Мытищинского района.</p>
-                        <div class="flex items-center text-sm text-gray-500">
+                        <p class="text-gray-600 mb-4 flex-grow">Областная клиническая больница, оказывающая широкий спектр медицинских услуг населению Мытищинского района.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
                             <span>г. Мытищи, ул. Коминтерна, 24</span>
                         </div>
@@ -530,9 +530,6 @@
                 
                 <!-- Popular Plan -->
                 <div class="service-card bg-blue-800 text-white transform scale-105 relative">
-                    <div class="absolute top-0 right-0 bg-red-500 text-white px-3 py-1 text-sm font-bold rounded-bl-lg">
-                        Популярный
-                    </div>
                     <div class="p-8 text-center">
                         <h3 class="text-xl font-bold mb-4">Стандартная помощь</h3>
                         <div class="text-4xl font-bold mb-6">7 000 ₽</div>

--- a/index.html
+++ b/index.html
@@ -394,9 +394,6 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
                 <!-- Partner 1 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://monikiweb.ru/templates/moniki/images/logo.png" alt="МОНИКИ им. М.Ф. Владимирского" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "МОНИКИ им. М.Ф. Владимирского"</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Ведущий научно-исследовательский и лечебный центр Московской области, специализирующийся на разработке и внедрении новых методов диагностики и лечения.</p>
@@ -409,9 +406,6 @@
                 
                 <!-- Partner 2 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://botkinmoscow.ru/local/templates/botkin/images/logo.svg" alt="Центр имени С.П. Боткина" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «Московский многопрофильный научно-клинический центр имени С.П. Боткина» ДЗМ</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Один из крупнейших многопрофильных медицинских центров Москвы с богатой историей и современным оборудованием.</p>
@@ -424,9 +418,6 @@
                 
                 <!-- Partner 3 - Бюро судебно-медицинской экспертизы -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://bsme.mos.ru/local/templates/bsme/images/logo.svg" alt="Бюро судебно-медицинской экспертизы ДЗМ" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «Бюро судебно-медицинской экспертизы ДЗМ»</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Ведущее учреждение судебно-медицинской экспертизы, обеспечивающее высококвалифицированную экспертную помощь правоохранительным органам и населению.</p>
@@ -439,9 +430,6 @@
                 
                 <!-- Partner 4 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://sklif.mos.ru/local/templates/sklif/images/logo.svg" alt="НИИ скорой помощи им. Н.В. Склифосовского" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «НИИ скорой помощи им. Н.В. Склифосовского»</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Ведущее учреждение экстренной медицинской помощи, специализирующееся на лечении неотложных состояний и травм.</p>
@@ -454,9 +442,6 @@
                 
                 <!-- Partner 5 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://67gkb.ru/local/templates/gkb67/images/logo.svg" alt="ГКБ № 67 им. Л.А. Ворохобова" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «ГКБ № 67 им. Л.А. Ворохобова» ДЗМ</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Многопрофильная клиническая больница с современным оборудованием и высококвалифицированными специалистами.</p>
@@ -469,9 +454,6 @@
                 
                 <!-- Partner 6 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://mytishchi-okb.ru/wp-content/uploads/2022/01/logo.png" alt="Мытищинская ОКБ" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "Мытищинская ОКБ"</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Областная клиническая больница, оказывающая широкий спектр медицинских услуг населению Мытищинского района.</p>
@@ -484,9 +466,6 @@
                 
                 <!-- Partner 7 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://ssmp.mos.ru/local/templates/ssmp/images/logo.svg" alt="Станция скорой помощи им. А.С. Пучкова" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «Станция скорой и неотложной помощи им. А.С. Пучкова»</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Крупнейшая в Европе станция скорой медицинской помощи, обеспечивающая экстренную помощь жителям Москвы.</p>
@@ -499,9 +478,6 @@
                 
                 <!-- Partner 8 - ЦГБ им. Н.А. Семашко -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://cgb-semashko.ru/wp-content/uploads/2022/01/logo.png" alt="ЦГБ им. Н.А. Семашко" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУ Ростовской области «ЦГБ им. Н.А. Семашко» г. Ростов-на-Дону</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Крупнейшая многопрофильная больница Ростова-на-Дону, оказывающая высококвалифицированную медицинскую помощь населению.</p>
@@ -514,9 +490,6 @@
                 
                 <!-- Partner 9 - Департамент социальной защиты -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://mintrud.donland.ru/upload/uf/e9c/e9c0c0a9c0a9c0a9c0a9c0a9c0a9c0a9.png" alt="Департамент социальной защиты населения г. Ростова-на-Дону" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">Департамент социальной защиты населения г. Ростова-на-Дону</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Государственный орган, обеспечивающий социальную поддержку и защиту населения Ростова-на-Дону.</p>
@@ -529,9 +502,6 @@
                 
                 <!-- Partner 10 - Волоколамская больница -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://volokolamsk-crb.ru/wp-content/uploads/2022/01/logo.png" alt="Волоколамская больница" class="max-h-32 max-w-full p-4">
-                    </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "Волоколамская больница"</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Многопрофильное медицинское учреждение, оказывающее квалифицированную медицинскую помощь жителям Волоколамского района.</p>
@@ -543,7 +513,7 @@
                 </div>
             </div>
             
-            <div class="mt-16 text-center">
+            <div class="mt-16 text-center hidden">
                 <a href="#contact" class="inline-block bg-blue-800 hover:bg-blue-900 text-white px-8 py-3 rounded-full font-medium transition duration-300">
                     Стать нашим партнером
                 </a>

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
                 <!-- Partner 1 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
                     <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://i.ibb.co/Jj9LKND/moniki-logo.png" alt="МОНИКИ им. М.Ф. Владимирского" class="max-h-32 max-w-full p-4">
+                        <img src="https://monikiweb.ru/templates/moniki/images/logo.png" alt="МОНИКИ им. М.Ф. Владимирского" class="max-h-32 max-w-full p-4">
                     </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "МОНИКИ им. М.Ф. Владимирского"</h3>
@@ -410,10 +410,10 @@
                 <!-- Partner 2 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
                     <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://i.ibb.co/Qf7Lvxb/botkin-logo.png" alt="Центр имени С.П. Боткина" class="max-h-32 max-w-full p-4">
+                        <img src="https://botkinmoscow.ru/local/templates/botkin/images/logo.svg" alt="Центр имени С.П. Боткина" class="max-h-32 max-w-full p-4">
                     </div>
                     <div class="p-6 flex-grow flex flex-col">
-                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «Московский многопрофильный центр имени С.П. Боткина»</h3>
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «Московский многопрофильный научно-клинический центр имени С.П. Боткина» ДЗМ</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Один из крупнейших многопрофильных медицинских центров Москвы с богатой историей и современным оборудованием.</p>
                         <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
@@ -422,13 +422,28 @@
                     </div>
                 </div>
                 
-                <!-- Partner 3 -->
+                <!-- Partner 3 - Бюро судебно-медицинской экспертизы -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
                     <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://i.ibb.co/Jc9Hnzw/sklif-logo.png" alt="НИИ скорой помощи им. Н.В. Склифосовского" class="max-h-32 max-w-full p-4">
+                        <img src="https://bsme.mos.ru/local/templates/bsme/images/logo.svg" alt="Бюро судебно-медицинской экспертизы ДЗМ" class="max-h-32 max-w-full p-4">
                     </div>
                     <div class="p-6 flex-grow flex flex-col">
-                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «НИИ скорой помощи им. Н.В. Склифосовского»</h3>
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «Бюро судебно-медицинской экспертизы ДЗМ»</h3>
+                        <p class="text-gray-600 mb-4 flex-grow">Ведущее учреждение судебно-медицинской экспертизы, обеспечивающее высококвалифицированную экспертную помощь правоохранительным органам и населению.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, Тарный проезд, 3</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 4 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://sklif.mos.ru/local/templates/sklif/images/logo.svg" alt="НИИ скорой помощи им. Н.В. Склифосовского" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6 flex-grow flex flex-col">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «НИИ скорой помощи им. Н.В. Склифосовского»</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Ведущее учреждение экстренной медицинской помощи, специализирующееся на лечении неотложных состояний и травм.</p>
                         <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
@@ -437,13 +452,13 @@
                     </div>
                 </div>
                 
-                <!-- Partner 4 -->
+                <!-- Partner 5 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
                     <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://i.ibb.co/Qj9Nt9L/gkb67-logo.png" alt="ГКБ № 67 им. Л.А. Ворохобова" class="max-h-32 max-w-full p-4">
+                        <img src="https://67gkb.ru/local/templates/gkb67/images/logo.svg" alt="ГКБ № 67 им. Л.А. Ворохобова" class="max-h-32 max-w-full p-4">
                     </div>
                     <div class="p-6 flex-grow flex flex-col">
-                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «ГКБ № 67 им. Л.А. Ворохобова»</h3>
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «ГКБ № 67 им. Л.А. Ворохобова» ДЗМ</h3>
                         <p class="text-gray-600 mb-4 flex-grow">Многопрофильная клиническая больница с современным оборудованием и высококвалифицированными специалистами.</p>
                         <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
                             <i class="fas fa-map-marker-alt mr-2"></i>
@@ -452,25 +467,10 @@
                     </div>
                 </div>
                 
-                <!-- Partner 5 -->
-                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
-                    <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://i.ibb.co/Jj9LKND/ssmp-logo.png" alt="Станция скорой помощи им. А.С. Пучкова" class="max-h-32 max-w-full p-4">
-                    </div>
-                    <div class="p-6 flex-grow flex flex-col">
-                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «Станция скорой помощи им. А.С. Пучкова»</h3>
-                        <p class="text-gray-600 mb-4 flex-grow">Крупнейшая в Европе станция скорой медицинской помощи, обеспечивающая экстренную помощь жителям Москвы.</p>
-                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
-                            <i class="fas fa-map-marker-alt mr-2"></i>
-                            <span>г. Москва, 1-й Коптельский пер., 3, стр. 1</span>
-                        </div>
-                    </div>
-                </div>
-                
                 <!-- Partner 6 -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
                     <div class="h-48 bg-blue-50 flex items-center justify-center">
-                        <img src="https://i.ibb.co/Qj9Nt9L/mytishi-logo.png" alt="Мытищинская ОКБ" class="max-h-32 max-w-full p-4">
+                        <img src="https://mytishchi-okb.ru/wp-content/uploads/2022/01/logo.png" alt="Мытищинская ОКБ" class="max-h-32 max-w-full p-4">
                     </div>
                     <div class="p-6 flex-grow flex flex-col">
                         <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "Мытищинская ОКБ"</h3>
@@ -481,10 +481,69 @@
                         </div>
                     </div>
                 </div>
+                
+                <!-- Partner 7 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://ssmp.mos.ru/local/templates/ssmp/images/logo.svg" alt="Станция скорой помощи им. А.С. Пучкова" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6 flex-grow flex flex-col">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ Г. Москвы «Станция скорой и неотложной помощи им. А.С. Пучкова»</h3>
+                        <p class="text-gray-600 mb-4 flex-grow">Крупнейшая в Европе станция скорой медицинской помощи, обеспечивающая экстренную помощь жителям Москвы.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, 1-й Коптельский пер., 3, стр. 1</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 8 - ЦГБ им. Н.А. Семашко -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://cgb-semashko.ru/wp-content/uploads/2022/01/logo.png" alt="ЦГБ им. Н.А. Семашко" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6 flex-grow flex flex-col">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУ Ростовской области «ЦГБ им. Н.А. Семашко» г. Ростов-на-Дону</h3>
+                        <p class="text-gray-600 mb-4 flex-grow">Крупнейшая многопрофильная больница Ростова-на-Дону, оказывающая высококвалифицированную медицинскую помощь населению.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Ростов-на-Дону, пр. Ворошиловский, 105</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 9 - Департамент социальной защиты -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://mintrud.donland.ru/upload/uf/e9c/e9c0c0a9c0a9c0a9c0a9c0a9c0a9c0a9.png" alt="Департамент социальной защиты населения г. Ростова-на-Дону" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6 flex-grow flex flex-col">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">Департамент социальной защиты населения г. Ростова-на-Дону</h3>
+                        <p class="text-gray-600 mb-4 flex-grow">Государственный орган, обеспечивающий социальную поддержку и защиту населения Ростова-на-Дону.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Ростов-на-Дону, ул. Большая Садовая, 47</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 10 - Волоколамская больница -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2 flex flex-col h-full">
+                    <div class="h-48 bg-blue-50 flex items-center justify-center">
+                        <img src="https://volokolamsk-crb.ru/wp-content/uploads/2022/01/logo.png" alt="Волоколамская больница" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6 flex-grow flex flex-col">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "Волоколамская больница"</h3>
+                        <p class="text-gray-600 mb-4 flex-grow">Многопрофильное медицинское учреждение, оказывающее квалифицированную медицинскую помощь жителям Волоколамского района.</p>
+                        <div class="flex items-center text-sm text-gray-500 mt-auto pt-3 border-t border-gray-100">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Волоколамск, ул. Парковая, 12</span>
+                        </div>
+                    </div>
+                </div>
             </div>
             
             <div class="mt-16 text-center">
-                <p class="text-gray-600 max-w-3xl mx-auto mb-8">Мы также сотрудничаем с другими медицинскими учреждениями, включая ГБУ Ростовской области «ЦГБ им. Н.А. Семашко», Департамент социальной защиты населения г. Ростова-на-Дону, ГБУЗ МО "Волоколамская больница" и многие другие.</p>
                 <a href="#contact" class="inline-block bg-blue-800 hover:bg-blue-900 text-white px-8 py-3 rounded-full font-medium transition duration-300">
                     Стать нашим партнером
                 </a>

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
                 <div class="hidden md:flex items-center space-x-6 whitespace-nowrap">
                     <a href="#services" class="text-white hover:text-red-300 font-medium px-2">Услуги</a>
                     <a href="#about" class="text-white hover:text-red-300 font-medium px-2">О нас</a>
+                    <a href="#partners" class="text-white hover:text-red-300 font-medium px-2">Партнеры</a>
                     <a href="#pricing" class="text-white hover:text-red-300 font-medium px-2">Цены</a>
                     <a href="#full-price-list" class="text-white hover:text-red-300 font-medium px-2">Прайс-лист</a>
                     <a href="#testimonials" class="text-white hover:text-red-300 font-medium px-2">Отзывы</a>
@@ -124,6 +125,7 @@
                 <div class="px-2 pt-2 pb-4 space-y-1">
                     <a href="#services" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100">Услуги</a>
                     <a href="#about" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100">О нас</a>
+                    <a href="#partners" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100">Партнеры</a>
                     <a href="#pricing" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100">Цены</a>
                     <a href="#full-price-list" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100">Прайс-лист</a>
                     <a href="#testimonials" class="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100">Отзывы</a>
@@ -341,19 +343,14 @@
             <div class="mt-10 grid grid-cols-1 lg:grid-cols-2 gap-8">
                 <!-- Left Column -->
                 <div>
-                  <h3 class="text-2xl font-bold text-blue-800 mb-4">Наши партнеры</h3>
-                  <p class="text-gray-600 mb-4">Мы успешно сотрудничаем с ведущими медицинскими государственными учреждениями, такими как:</p>
+                  <h3 class="text-2xl font-bold text-blue-800 mb-4">Наши достижения</h3>
+                  <p class="text-gray-600 mb-4">За годы работы мы достигли значительных результатов в сфере медицинской транспортировки:</p>
                   <ul class="list-disc list-inside text-gray-700 space-y-1">
-                    <li>ГБУЗ МО "МОНИКИ им. М.Ф. Владимирского"</li>
-                    <li>ГБУЗ Г. Москвы «Московский многопрофильный научно-клинический центр имени С.П. Боткина» ДЗМ</li>
-                    <li>ГБУЗ Г. Москвы «Бюро судебно-медицинской экспертизы ДЗМ»</li>
-                    <li>ГБУЗ Г. Москвы «НИИ скорой помощи им. Н.В. Склифосовского»</li>
-                    <li>ГБУЗ Г. Москвы «ГКБ № 67 им. Л.А. Ворохобова» ДЗМ</li>
-                    <li>ГБУЗ МО "Мытищинская ОКБ"</li>
-                    <li>ГБУЗ Г. Москвы «Станция скорой и неотложной помощи им. А.С. Пучкова»</li>
-                    <li>ГБУ Ростовской области «ЦГБ им. Н.А. Семашко» г. Ростов-на-Дону</li>
-                    <li>Департамент социальной защиты населения г. Ростова-на-Дону</li>
-                    <li>ГБУЗ МО "Волоколамская больница" и другие</li>
+                    <li>Более 10 000 успешных перевозок пациентов</li>
+                    <li>Свыше 500 экстренных реанимационных транспортировок</li>
+                    <li>Более 100 межрегиональных медицинских перевозок</li>
+                    <li>Успешное сотрудничество с десятками медицинских учреждений</li>
+                    <li>Высокий уровень удовлетворенности клиентов</li>
                   </ul>
                 </div>
               
@@ -385,6 +382,113 @@
                 </div>
               </div>
             
+        </div>
+    </section>
+
+    <!-- Partners Section -->
+    <section id="partners" class="py-20 bg-blue-50">
+        <div class="container mx-auto px-4">
+            <h2 class="text-3xl md:text-4xl font-bold text-center mb-4 text-blue-800">Наши партнеры</h2>
+            <p class="text-center text-gray-600 max-w-2xl mx-auto mb-16">Мы успешно сотрудничаем с ведущими медицинскими государственными учреждениями</p>
+            
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
+                <!-- Partner 1 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
+                    <div class="h-48 bg-gray-200 flex items-center justify-center">
+                        <img src="https://monikiweb.ru/templates/moniki/images/logo.png" alt="МОНИКИ им. М.Ф. Владимирского" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "МОНИКИ им. М.Ф. Владимирского"</h3>
+                        <p class="text-gray-600 mb-4">Ведущий научно-исследовательский и лечебный центр Московской области, специализирующийся на разработке и внедрении новых методов диагностики и лечения.</p>
+                        <div class="flex items-center text-sm text-gray-500">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, ул. Щепкина, 61/2</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 2 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
+                    <div class="h-48 bg-gray-200 flex items-center justify-center">
+                        <img src="https://botkinmoscow.ru/upload/iblock/a0c/a0c4d1a9a5a5e8c5e8c5e8c5e8c5e8c5.png" alt="Центр имени С.П. Боткина" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «Московский многопрофильный центр имени С.П. Боткина»</h3>
+                        <p class="text-gray-600 mb-4">Один из крупнейших многопрофильных медицинских центров Москвы с богатой историей и современным оборудованием.</p>
+                        <div class="flex items-center text-sm text-gray-500">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, 2-й Боткинский проезд, 5</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 3 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
+                    <div class="h-48 bg-gray-200 flex items-center justify-center">
+                        <img src="https://sklif.mos.ru/upload/medialibrary/e97/e97a75d3f4c919a289ebfa47a4a1c5c0.png" alt="НИИ скорой помощи им. Н.В. Склифосовского" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «НИИ скорой помощи им. Н.В. Склифосовского»</h3>
+                        <p class="text-gray-600 mb-4">Ведущее учреждение экстренной медицинской помощи, специализирующееся на лечении неотложных состояний и травм.</p>
+                        <div class="flex items-center text-sm text-gray-500">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, Большая Сухаревская площадь, 3</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 4 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
+                    <div class="h-48 bg-gray-200 flex items-center justify-center">
+                        <img src="https://67gkb.ru/local/templates/gkb67/images/logo.svg" alt="ГКБ № 67 им. Л.А. Ворохобова" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «ГКБ № 67 им. Л.А. Ворохобова»</h3>
+                        <p class="text-gray-600 mb-4">Многопрофильная клиническая больница с современным оборудованием и высококвалифицированными специалистами.</p>
+                        <div class="flex items-center text-sm text-gray-500">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, ул. Саляма Адиля, 2/44</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 5 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
+                    <div class="h-48 bg-gray-200 flex items-center justify-center">
+                        <img src="https://ssmp.mos.ru/images/logo.png" alt="Станция скорой помощи им. А.С. Пучкова" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ «Станция скорой помощи им. А.С. Пучкова»</h3>
+                        <p class="text-gray-600 mb-4">Крупнейшая в Европе станция скорой медицинской помощи, обеспечивающая экстренную помощь жителям Москвы.</p>
+                        <div class="flex items-center text-sm text-gray-500">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Москва, 1-й Коптельский пер., 3, стр. 1</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Partner 6 -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:-translate-y-2">
+                    <div class="h-48 bg-gray-200 flex items-center justify-center">
+                        <img src="https://mytishchi-okb.ru/wp-content/uploads/2022/01/logo.png" alt="Мытищинская ОКБ" class="max-h-32 max-w-full p-4">
+                    </div>
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-3 text-blue-800">ГБУЗ МО "Мытищинская ОКБ"</h3>
+                        <p class="text-gray-600 mb-4">Областная клиническая больница, оказывающая широкий спектр медицинских услуг населению Мытищинского района.</p>
+                        <div class="flex items-center text-sm text-gray-500">
+                            <i class="fas fa-map-marker-alt mr-2"></i>
+                            <span>г. Мытищи, ул. Коминтерна, 24</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="mt-16 text-center">
+                <p class="text-gray-600 max-w-3xl mx-auto mb-8">Мы также сотрудничаем с другими медицинскими учреждениями, включая ГБУ Ростовской области «ЦГБ им. Н.А. Семашко», Департамент социальной защиты населения г. Ростова-на-Дону, ГБУЗ МО "Волоколамская больница" и многие другие.</p>
+                <a href="#contact" class="inline-block bg-blue-800 hover:bg-blue-900 text-white px-8 py-3 rounded-full font-medium transition duration-300">
+                    Стать нашим партнером
+                </a>
+            </div>
         </div>
     </section>
 


### PR DESCRIPTION
This PR adds a new partners section between the about and pricing sections. The changes include:

- Moving the partners list from the about section to a dedicated partners section
- Adding detailed information about each partner organization
- Including images for each partner
- Updating the navigation menu to include the new partners section
- Replacing the partners list in the about section with achievements